### PR TITLE
Merged:  `feature/lineup` --> `main`

### DIFF
--- a/src/pages/events/liquid-dreams-volume-3.astro
+++ b/src/pages/events/liquid-dreams-volume-3.astro
@@ -24,7 +24,7 @@ const metadata = {
         target: '_blank',
         icon: 'tabler:ticket',
       },
-      { text: 'Lineup', href: '#features' },
+      { text: 'Lineup', href: '#lineup' },
     ]}
   >
     <Fragment slot="title">

--- a/src/pages/events/liquid-dreams-volume-3.astro
+++ b/src/pages/events/liquid-dreams-volume-3.astro
@@ -51,7 +51,7 @@ const metadata = {
 
   <!-- Features Widget *************** -->
 
-  <!-- <Features
+  <Features
     id="lineup"
     tagline="Lineup"
     title="Event Schedule"
@@ -88,7 +88,7 @@ const metadata = {
         icon: 'tabler:chart-pie',
       },
     ]}
-  /> -->
+  />
 
   <!-- CallToAction Widget *********** -->
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ const metadata = {
         href: '/events/liquid-dreams-volume-3#ticket',
         icon: 'tabler:ticket',
       },
-      { text: 'Lineup', href: '#features' },
+      { text: 'Lineup', href: '/events/liquid-dreams-volume-3#lineup' },
     ]}
     image={{ src: '~/assets/images/Logo_LiquidDreams_ringOnly_compressed.png', alt: 'LiQuid Dreams' }}
   >


### PR DESCRIPTION
#### Modified:


File: `index.astro`

↳ (src/pages/index.astro)

- Enabled `#lineup` navigation from the index page to the event page

<br/>

File: `liquid-dreams-volume-3.astro`

↳ (src/pages/events/liquid-dreams-volume-3.astro)

- Enabled `#lineup` on the event page
- Released the `<Features />` component for the lineup